### PR TITLE
MAINT: force complex

### DIFF
--- a/refellips/structureSE.py
+++ b/refellips/structureSE.py
@@ -630,7 +630,9 @@ class SlabSE(ComponentSE):
         if self.ri.dispersive:
             ric = self.ri.complex(getattr(structure, "wavelength", None))
         else:
-            ric = complex(self.ri)
+            ric = self.ri
+
+        ric = complex(ric)
 
         return np.array(
             [


### PR DESCRIPTION
Has the effect of forcing np arrays of length 1 to the Python `complex` type. This code will produce an error if the array has len > 1, which is what we want in the `slabs` method. `slabs` wasn't designed to work with `ric` being an array of len == 1 either, which is why I made this change.