### PR TITLE
Delta residual fix

### DIFF
--- a/refellips/dataSE.py
+++ b/refellips/dataSE.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-""""
+""" "
 A basic representation of a 1D dataset
 """
 

--- a/refellips/dataSE.py
+++ b/refellips/dataSE.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-""" "
+"""
 A basic representation of a 1D dataset
 """
 

--- a/refellips/objectiveSE.py
+++ b/refellips/objectiveSE.py
@@ -178,9 +178,9 @@ class ObjectiveSE(BaseObjective):
 
         wavelength, aoi, psi_d, delta_d = self.data.data
         wavelength_aoi = np.c_[wavelength, aoi]
-
         psi, delta = self.model(wavelength_aoi)
-        return np.r_[psi - psi_d, delta - delta_d]
+        delta_err = (delta - delta_d + 180) % 360 - 180
+        return np.r_[psi - psi_d, delta_err]
 
     def chisqr(self, pvals=None):
         """
@@ -369,16 +369,16 @@ class ObjectiveSE(BaseObjective):
 
         psi, delta = self.model(wavelength_aoi)
 
-        model = np.r_[psi, delta]
-
         logl = 0.0
 
         # TODO investigate ellipsometry uncertainties
         # here just set it to unity
         y_err = 1
         if self.lnsigma is not None:
+            _model = np.r_[psi, delta]
             var_y = (
-                y_err * y_err + np.exp(2 * float(self.lnsigma)) * model * model
+                y_err * y_err
+                + np.exp(2 * float(self.lnsigma)) * _model * _model
             )
         else:
             var_y = y_err**2
@@ -387,7 +387,8 @@ class ObjectiveSE(BaseObjective):
         if self.weighted:
             logl += np.log(2 * np.pi * var_y)
 
-        logl += (np.r_[psi_d, delta_d] - model) ** 2 / var_y
+        res = self.residuals(None)
+        logl += (res) ** 2 / var_y
 
         # nans play havoc
         if np.isnan(logl).any():

--- a/refellips/objectiveSE.py
+++ b/refellips/objectiveSE.py
@@ -22,10 +22,14 @@ def circular_distance(angle1, angle2, period=2 * np.pi):
     """
     Calculates the circular distance between two angles.
 
-    Args:
-        angle1 (float or np.ndarray): The first angle(s) in radians.
-        angle2 (float or np.ndarray): The second angle(s) in radians.
-        period (float): The period of the circular domain (e.g., 2*np.pi for full circle).
+    Parameters
+    ----------
+    angle1 : float, np.ndarray
+        First angle
+    angle2 : float, np.ndarray
+        Second angle
+    period : float
+        The period of the circular domain (e.g., 2*np.pi for full circle).
 
     Returns:
         float or np.ndarray: The shortest circular distance between the angles.

--- a/refellips/objectiveSE.py
+++ b/refellips/objectiveSE.py
@@ -18,6 +18,22 @@ from refnx._lib import unique as f_unique
 from refnx._lib import flatten
 
 
+def circular_distance(angle1, angle2, period=2*np.pi):
+    """
+    Calculates the circular distance between two angles.
+
+    Args:
+        angle1 (float or np.ndarray): The first angle(s) in radians.
+        angle2 (float or np.ndarray): The second angle(s) in radians.
+        period (float): The period of the circular domain (e.g., 2*np.pi for full circle).
+
+    Returns:
+        float or np.ndarray: The shortest circular distance between the angles.
+    """
+    diff = np.abs(angle1 - angle2)
+    return np.minimum(diff, period - diff)
+
+
 class ObjectiveSE(BaseObjective):
     """
     Objective function for using with curvefitters such as
@@ -179,7 +195,7 @@ class ObjectiveSE(BaseObjective):
         wavelength, aoi, psi_d, delta_d = self.data.data
         wavelength_aoi = np.c_[wavelength, aoi]
         psi, delta = self.model(wavelength_aoi)
-        delta_err = (delta - delta_d + 180) % 360 - 180
+        delta_err = circular_distance(delta, delta_d, period=360)
         return np.r_[psi - psi_d, delta_err]
 
     def chisqr(self, pvals=None):

--- a/refellips/objectiveSE.py
+++ b/refellips/objectiveSE.py
@@ -18,7 +18,7 @@ from refnx._lib import unique as f_unique
 from refnx._lib import flatten
 
 
-def circular_distance(angle1, angle2, period=2*np.pi):
+def circular_distance(angle1, angle2, period=2 * np.pi):
     """
     Calculates the circular distance between two angles.
 

--- a/refellips/objectiveSE.py
+++ b/refellips/objectiveSE.py
@@ -18,9 +18,11 @@ from refnx._lib import unique as f_unique
 from refnx._lib import flatten
 
 
-def circular_distance(angle1, angle2, period=2 * np.pi):
+def circular_distance(angle1, angle2, period=360):
     """
     Calculates the circular distance between two angles.
+    Units (rad or deg) do not matter as long as they are
+    consistent.
 
     Parameters
     ----------
@@ -29,7 +31,7 @@ def circular_distance(angle1, angle2, period=2 * np.pi):
     angle2 : float, np.ndarray
         Second angle
     period : float
-        The period of the circular domain (e.g., 2*np.pi for full circle).
+        The period of the circular domain (e.g.,360 for full circle).
 
     Returns:
         float or np.ndarray: The shortest circular distance between the angles.

--- a/refellips/tests/test_refellips.py
+++ b/refellips/tests/test_refellips.py
@@ -512,7 +512,7 @@ def test_residuals():
     obj_delta_res = res[int(len(res) / 2) :]
 
     test_psi_res = psi_2 - psi_1
-    test_delta_res = (delta_2 - delta_1 + 180) % 360 - 180
+    test_delta_res = np.abs((delta_2 - delta_1 + 180) % 360 - 180)
 
     assert_allclose(test_psi_res, obj_psi_res, rtol=0.002)
     assert_allclose(test_delta_res, obj_delta_res, rtol=0.003)


### PR DESCRIPTION
Delta was not being treated as an angle when residuals were being calculated. For instance, the difference between 2˚ and 358 ˚ was calculated at 356˚, rather than 4˚. This typically doesn't cause an issue when datasets do not contain Delta close to 0/360 (so avoided detection) but can cause serious issues.

The current pull request fixes this calculation using:

(delta_model - delta_data + 180) % 360 – 180

Which is an efficent way of calculating the circular distance between two angles.